### PR TITLE
Fix gist update call

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -44,7 +44,7 @@ export const run = async (context: ActionContext): Promise<void> => {
   startGroup('Deploy to gist')
   if (gistId === undefined) {
     const response = await context.octokit.rest.gists.create({
-      files: { [gistFileName]: { content: PLACEHOLDER } },
+      files: { [gistFileName]: { content: PLACEHOLDER, filename: gistFileName } },
       public: createAsPublic
     })
     gistId = response.data.id!
@@ -56,7 +56,7 @@ export const run = async (context: ActionContext): Promise<void> => {
     await context.octokit.rest.gists.update({
       gist_id: gistId,
       description: gistDescription,
-      files: { [gistFileName]: { content } }
+      files: { [gistFileName]: { content, filename: gistFileName } },
     })
   } else {
     const git = simpleGit()


### PR DESCRIPTION
Should fix the issue in #98. 

I cannot seem to figure out why this issue started occurring, but I'm assuming it must be something on the side of Octokit or GitHub itself.

To those who want to test this PR before it's merged, you can change `uses: exuanbo/actions-deploy-gist@v1` to `uses: Raphiiko/actions-deploy-gist@main` in your workflows.